### PR TITLE
[WIP] Application ncoden

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,8 @@
             </div>
             <div class="editor-view">
                 <div class="card">
-                    <div class="name">Maël Nison</div>
-                    <div class="job">Frontend Developer</div>
+                    <div class="name"></div>
+                    <div class="job"></div>
                 </div>
             </div>
         </div>

--- a/sources/apis/editor/defaultWidgets.js
+++ b/sources/apis/editor/defaultWidgets.js
@@ -20,11 +20,38 @@ define( [
     'apis/editor/widgets/SlideredImage',
     'apis/editor/widgets/Slider',
     'apis/editor/widgets/Tabbed',
+    'apis/editor/widgets/Text',
     'apis/editor/widgets/ToggleSwitch',
     'apis/editor/widgets/Vertical',
     'apis/editor/widgets/Widget'
 
-], function ( AngleWidget, AnnotationWidget, AxisWidget, ButtonWidget, ColorWidget, FactoredImageWidget, FilePickerWidget, GroupWidget, HorizontalWidget, Hyde, ImageWidget, LabelWidget, NumberedSliderWidget, NumberWidget, OrientationWidget, RepeatWidget, SelectWidget, SlideredImageWidget, SliderWidget, TabbedWidget, ToggleSwitchWidget, VerticalWidget ) {
+], function (
+
+    AngleWidget,
+    AnnotationWidget,
+    AxisWidget,
+    ButtonWidget,
+    ColorWidget,
+    FactoredImageWidget,
+    FilePickerWidget,
+    GroupWidget,
+    HorizontalWidget,
+    Hyde,
+    ImageWidget,
+    LabelWidget,
+    NumberedSliderWidget,
+    NumberWidget,
+    OrientationWidget,
+    RepeatWidget,
+    SelectWidget,
+    SlideredImageWidget,
+    SliderWidget,
+    TabbedWidget,
+    TextWidget,
+    ToggleSwitchWidget,
+    VerticalWidget
+
+) {
 
     'use strict';
 
@@ -39,6 +66,7 @@ define( [
         Hyde: Hyde,
         Repeat: RepeatWidget,
 
+        Text: TextWidget,
         Image: ImageWidget,
         Color: ColorWidget,
         FactoredImage: FactoredImageWidget,

--- a/sources/apis/editor/defaultWidgets.js
+++ b/sources/apis/editor/defaultWidgets.js
@@ -16,6 +16,7 @@ define( [
     'apis/editor/widgets/Number',
     'apis/editor/widgets/Orientation',
     'apis/editor/widgets/Repeat',
+    'apis/editor/widgets/RichText',
     'apis/editor/widgets/Select',
     'apis/editor/widgets/SlideredImage',
     'apis/editor/widgets/Slider',
@@ -43,6 +44,7 @@ define( [
     NumberWidget,
     OrientationWidget,
     RepeatWidget,
+    RichTextWidget,
     SelectWidget,
     SlideredImageWidget,
     SliderWidget,
@@ -67,6 +69,7 @@ define( [
         Repeat: RepeatWidget,
 
         Text: TextWidget,
+        RichText: RichTextWidget,
         Image: ImageWidget,
         Color: ColorWidget,
         FactoredImage: FactoredImageWidget,

--- a/sources/apis/editor/widgets/Color.js
+++ b/sources/apis/editor/widgets/Color.js
@@ -37,18 +37,18 @@ define( [
             options = _.defaults( options || {}, {
 
                 model: new Backbone.Model(),
-                name: 'value'
+                name: 'value',
+                format: 'rgb'
 
             } );
 
             Widget.prototype.initialize.call( this, options );
 
-            if ( typeof this.get() === 'undefined' )
-                this.set( {
-                    r: 1,
-                    g: 1,
-                    b: 1
-                } );
+            var color = this.get() || {
+                r: 1,
+                g: 1,
+                b: 1
+            };
 
             this.colorPicker = SvgColorPicker( {
 
@@ -60,9 +60,12 @@ define( [
 
             }, function ( hsv, rgb /*, hex*/ ) {
 
-                this.change( rgb );
+                var color = this.convertColor( rgb, { from: 'rgb' } );
+                this.set( color );
 
             }.bind( this ) );
+
+            this.set( color );
 
         },
 
@@ -74,9 +77,12 @@ define( [
 
         render: function () {
 
-            var rgb = this.get();
+            var hex = this.convertColor( this.get(), { to: 'hex' } );
+            this.$( '.value' ).val( hex );
 
-            this.colorPicker.set( rgb );
+        },
+
+        rgbToHex: function ( rgb ) {
 
             var rounded = {
                 r: rgb.r * 255,
@@ -85,8 +91,36 @@ define( [
             };
             var hex = '#' + ( 16777216 | rounded.b | ( rounded.g << 8 ) | ( rounded.r << 16 ) ).toString( 16 ).substr( 1 );
 
-            this.$( '.value' ).val( hex );
+            return hex;
+        },
 
+        hexToRgb: function ( hex ) {
+
+            // https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
+            var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+            return result ? {
+                r: parseInt(result[1], 16),
+                g: parseInt(result[2], 16),
+                b: parseInt(result[3], 16)
+            } : null;
+        },
+
+        convertColor: function ( color, options ) {
+
+            var from = options.from || this.options.format;
+            var to = options.to || this.options.format;
+
+            if ( from != to ) {
+
+                if ( from == 'hex' )
+                    color = this.hexToRgb( color );
+
+                if ( to == 'hex' )
+                    color = this.rgbToHex( color );
+
+            }
+
+            return color;
         }
 
     } );

--- a/sources/apis/editor/widgets/Color.js
+++ b/sources/apis/editor/widgets/Color.js
@@ -99,9 +99,9 @@ define( [
             // https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
             var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
             return result ? {
-                r: parseInt(result[1], 16),
-                g: parseInt(result[2], 16),
-                b: parseInt(result[3], 16)
+                r: parseInt(result[1], 16) / 255,
+                g: parseInt(result[2], 16) / 255,
+                b: parseInt(result[3], 16) / 255
             } : null;
         },
 

--- a/sources/apis/editor/widgets/Color.js
+++ b/sources/apis/editor/widgets/Color.js
@@ -49,6 +49,7 @@ define( [
                 g: 1,
                 b: 1
             };
+            var rgb = this.convertColor( color, { to: 'rgb' } );
 
             this.colorPicker = SvgColorPicker( {
 
@@ -66,6 +67,7 @@ define( [
             }.bind( this ) );
 
             this.set( color );
+            this.colorPicker.set( rgb );
 
         },
 

--- a/sources/apis/editor/widgets/RichText.js
+++ b/sources/apis/editor/widgets/RichText.js
@@ -4,15 +4,15 @@ define( [
     'vendors/JQuery',
     'vendors/Underscore',
 
-    'apis/editor/widgets/Horizontal',
+    'apis/editor/widgets/Vertical',
 
-], function ( Backbone, $, _, HorizontalWidget ) {
+], function ( Backbone, $, _, VerticalWidget ) {
 
     'use strict';
 
-    return HorizontalWidget.extend( {
+    return VerticalWidget.extend( {
 
-        el: [ ' <div class="widget layout-widget horizontal-widget rich-text-widget">',
+        el: [ ' <div class="widget layout-widget vertical-widget rich-text-widget">',
             '       <div class="widget-wrapper">',
             '           <div class="children"></div>',
             '       </div>',
@@ -28,7 +28,7 @@ define( [
 
             }, options );
 
-            HorizontalWidget.prototype.initialize.call( this, options );
+            VerticalWidget.prototype.initialize.call( this, options );
 
             var common = {
                 model: this.model,

--- a/sources/apis/editor/widgets/RichText.js
+++ b/sources/apis/editor/widgets/RichText.js
@@ -1,0 +1,44 @@
+define( [
+
+    'vendors/Backbone',
+    'vendors/JQuery',
+    'vendors/Underscore',
+
+    'apis/editor/widgets/Horizontal',
+
+], function ( Backbone, $, _, HorizontalWidget ) {
+
+    'use strict';
+
+    return HorizontalWidget.extend( {
+
+        el: [ ' <div class="widget layout-widget horizontal-widget rich-text-widget">',
+            '       <div class="widget-wrapper">',
+            '           <div class="children"></div>',
+            '       </div>',
+            '   </div>'
+        ].join( '' ),
+
+        initialize: function ( options ) {
+
+            options = _.defaults( options || {}, {
+
+                model: new Backbone.Model(),
+                name: 'value'
+
+            }, options );
+
+            HorizontalWidget.prototype.initialize.call( this, options );
+
+            var common = {
+                model: this.model,
+            };
+            this.text = this.createWidget( 'Text', _.extend( {}, common, { name: this.field( 'text' ) }, this.options.textOptions ) );
+            this.size = this.createWidget( 'Number', _.extend( {}, common, { name: this.field( 'size' ) }, this.options.sizeOptions ) );
+            this.color = this.createWidget( 'Color', _.extend( {}, common, { name: this.field( 'color' ) }, this.options.colorOptions ) );
+
+        }
+
+    } );
+
+} );

--- a/sources/apis/editor/widgets/Text.js
+++ b/sources/apis/editor/widgets/Text.js
@@ -1,0 +1,55 @@
+define( [
+
+    'vendors/Backbone',
+    'vendors/JQuery',
+    'vendors/Underscore',
+
+    'apis/editor/widgets/Widget'
+
+], function ( Backbone, $, _, Widget ) {
+
+    'use strict';
+
+    return Widget.extend( {
+
+        el: [ '<div class="widget text-widget">',
+            '      <input type="text" class="js-text">',
+            '  </div>'
+        ].join( '' ),
+
+        events: _.extend( {}, Widget.prototype.events, {
+            'change .js-text:input': 'changeEvent',
+            'keydown .js-text:input': 'changeEvent',
+            'keyup .js-text:input': 'changeEvent'
+        } ),
+
+        initialize: function ( options ) {
+
+            options = _.defaults( options || {}, {
+
+                model: new Backbone.Model(),
+                name: 'value'
+
+            }, options );
+
+            Widget.prototype.initialize.call( this, options );
+
+            if ( typeof this.get( ) === 'undefined' )
+                this.set( '' );
+        },
+
+        render: function ( ) {
+
+            this.$el.find( '.js-text' ).val( this.get() );
+
+        },
+
+        changeEvent: function ( e ) {
+
+            this.set( this.$('.js-text').val() );
+
+        }
+
+    } );
+
+} );

--- a/sources/apis/editor/widgets/Widget.js
+++ b/sources/apis/editor/widgets/Widget.js
@@ -244,7 +244,7 @@ define( [
 
         defaultAction: function ( which, value ) {
 
-            this.set( value );
+            this.set( which, value );
 
         },
 

--- a/sources/apis/editor/widgets/Widget.js
+++ b/sources/apis/editor/widgets/Widget.js
@@ -2,9 +2,11 @@ define( [
 
     'vendors/Backbone',
     'vendors/JQuery',
-    'vendors/Underscore'
+    'vendors/Underscore',
 
-], function ( Backbone, $, _ ) {
+    'utils/DeepObject'
+
+], function ( Backbone, $, _, DeepObject ) {
 
     'use strict';
 
@@ -175,16 +177,15 @@ define( [
         modelChangeEvent: function () {
 
             var name = this.options.name;
+            var keys = name.split( '.' );
             var namespace = name + '.';
 
             // If there is no name, then we catch every event
             var thereIsNoName = ! name;
 
-            // Is there some attribute that match the widget name ? (ie. a widget named "foo" will catch changes on properties "foo" and "foo.bar")
-            var changedAttributes = Object.keys( this.model.changedAttributes() || {} );
-            var hasInterestingChanges = changedAttributes.some( function ( attribute ) {
-                return attribute === name || attribute.indexOf( namespace ) === 0;
-            } );
+            // Check if the widget's object is in the changed attributes
+            var changedAttributes = this.model.changedAttributes() || {};
+            var hasInterestingChanges = DeepObject.has( changedAttributes, keys );
 
             if ( thereIsNoName || hasInterestingChanges ) {
                 this.render();
@@ -260,19 +261,22 @@ define( [
         /**
          * This function returns the value of a widget field from the model.
          *
-         * If specified, `which` is the name of the specific field requested. Only useful for some specific widgets.
+         * If specified, `which` is the name of the specific field or sub-field affected. Sub-field are separated by a dot ('.').
          */
 
         get: function ( which ) {
 
-            return this.model.get( this.field( which ) );
+            var keys = this.field( which ).split( '.' );
+            var value = DeepObject.get( this.model.attributes, keys );
+
+            return value;
 
         },
 
         /**
          * This function sets the value of a widget field from the model.
          *
-         * If specified, `which` is the name of the specific field affected. Only useful for some specific widgets.
+         * If specified, `which` is the name of the specific field or sub-field affected. Sub-field are separated by a dot ('.').
          */
 
         set: function ( which, value ) {
@@ -282,7 +286,27 @@ define( [
                 which = undefined;
             }
 
-            return this.model.set( this.field( which ), value );
+            var keys = this.field( which ).split( '.' );
+
+            // Because change events are manually triggered to handle deep change,
+            // we must verify there is actually a change.
+            if (DeepObject.get( this.model.attributes, keys ) !== value ) {
+
+                // To allow deep changes to be triggered before top changes, `model.set()` cannot be called.
+                // `model.changed` and `model.attributes` must be updated manually.
+                this.model.attributes = DeepObject.set( this.model.attributes, keys, value );
+                this.model.changed = DeepObject.set( { }, keys, value );
+
+                // Trigger changes
+                while ( keys.length > 0 ) {
+                    this.model.trigger( 'change:' + keys.join( '.' ) );
+                    keys.pop( );
+                }
+                this.model.trigger( 'change' );
+
+            }
+
+            return this.model;
 
         }
 

--- a/sources/app.js
+++ b/sources/app.js
@@ -13,6 +13,7 @@ define( [
 
         defaults : {
             radius : 10,
+            background: '#222222',
             padding: 50,
             title: {
                 text: 'Name',
@@ -33,6 +34,7 @@ define( [
         initialize : function ( ) {
             this.model.on( 'change:radius',     this.bindPropertyChange( 'radius', 'border-radius' ), this );
             this.model.on( 'change:padding',    this.bindPropertyChange( 'padding', 'padding' ), this );
+            this.model.on( 'change:background', this.bindPropertyChange( 'background', 'background-color' ), this );
             this.model.on( 'change:title',      this.bindRichTextChange( 'title', '.name' ), this );
             this.model.on( 'change:subtitle',   this.bindRichTextChange( 'subtitle', '.job' ), this );
             this.model.on( 'all',               this.debugChange, this );
@@ -41,6 +43,7 @@ define( [
         render : function ( ) {
             this.bindPropertyChange( 'radius', 'border-radius' )();
             this.bindPropertyChange( 'padding', 'padding' )();
+            this.bindPropertyChange( 'background', 'background-color' )();
             this.bindRichTextChange( 'title', '.name' )();
             this.bindRichTextChange( 'subtitle', '.job' )();
         },
@@ -85,6 +88,12 @@ define( [
     appearance.createWidget( 'Paddings', 'NumberedSlider', {
         model : card,
         name  : 'padding'
+    } );
+
+    appearance.createWidget( 'Background Color', 'Color', {
+        model : card,
+        name  : 'background',
+        format: 'hex'
     } );
 
     appearance.createWidget( 'Title', 'RichText', {

--- a/sources/app.js
+++ b/sources/app.js
@@ -76,27 +76,31 @@ define( [
 
     // --- --- --- --- --- --- --- --- ---
 
-    var appearance = editor.createWidget( 'Group', {
+    var appearanceGroup = editor.createWidget( 'Group', {
         label : 'Card Appearance'
     } );
 
-    appearance.createWidget( 'Border radius', 'NumberedSlider', {
+    appearanceGroup.createWidget( 'Border radius', 'NumberedSlider', {
         model : card,
         name  : 'radius'
     } );
 
-    appearance.createWidget( 'Paddings', 'NumberedSlider', {
+    appearanceGroup.createWidget( 'Paddings', 'NumberedSlider', {
         model : card,
         name  : 'padding'
     } );
 
-    appearance.createWidget( 'Background Color', 'Color', {
+    appearanceGroup.createWidget( 'Background Color', 'Color', {
         model : card,
         name  : 'background',
         format: 'hex'
     } );
 
-    appearance.createWidget( 'Title', 'RichText', {
+    var contentGroup = editor.createWidget( 'Group', {
+        label : 'Content'
+    } );
+
+    contentGroup.createWidget( 'Title', 'RichText', {
         model : card,
         name  : 'title',
         colorOptions : {
@@ -104,7 +108,7 @@ define( [
         },
     } );
 
-    appearance.createWidget( 'Subtitle', 'RichText', {
+    contentGroup.createWidget( 'Subtitle', 'RichText', {
         model : card,
         name  : 'subtitle',
         colorOptions : {

--- a/sources/app.js
+++ b/sources/app.js
@@ -31,21 +31,27 @@ define( [
     var View = Backbone.View.extend( {
 
         initialize : function ( ) {
-            this.model.on( 'change:radius', this.onRadiusChange, this );
-            this.model.on( 'change:padding', this.onPaddingChange, this );
-            this.model.on( 'change:title', this.bindRichTextChange( '.name', 'title' ), this );
-            this.model.on( 'change:subtitle', this.bindRichTextChange( '.job', 'subtitle' ), this );
-            this.model.on( 'all', this.debugChange, this );
+            this.model.on( 'change:radius',     this.bindPropertyChange( 'radius', 'border-radius' ), this );
+            this.model.on( 'change:padding',    this.bindPropertyChange( 'padding', 'padding' ), this );
+            this.model.on( 'change:title',      this.bindRichTextChange( 'title', '.name' ), this );
+            this.model.on( 'change:subtitle',   this.bindRichTextChange( 'subtitle', '.job' ), this );
+            this.model.on( 'all',               this.debugChange, this );
         },
 
         render : function ( ) {
-            this.onRadiusChange( );
-            this.onPaddingChange( );
-            this.bindRichTextChange( '.name', 'title' )();
-            this.bindRichTextChange( '.job', 'subtitle' )();
+            this.bindPropertyChange( 'radius', 'border-radius' )();
+            this.bindPropertyChange( 'padding', 'padding' )();
+            this.bindRichTextChange( 'title', '.name' )();
+            this.bindRichTextChange( 'subtitle', '.job' )();
         },
 
-        bindRichTextChange: function ( selector, key ) {
+        bindPropertyChange : function ( key, property ) {
+            return function ( ) {
+                this.$el.css( property, this.model.get( key ) );
+            }.bind( this );
+        },
+
+        bindRichTextChange: function ( key, selector ) {
             var $richText = this.$el.find( selector );
 
             return function ( ) {
@@ -54,14 +60,6 @@ define( [
                 $richText.css( 'font-size', datas.size );
                 $richText.css( 'color', datas.color );
             }.bind( this );
-        },
-
-        onRadiusChange : function ( ) {
-            this.$el.css( 'border-radius', this.model.get( 'radius' ) );
-        },
-
-        onPaddingChange : function ( ) {
-            this.$el.css( 'padding', this.model.get( 'padding' ) );
         }
 
     } );

--- a/sources/app.js
+++ b/sources/app.js
@@ -12,7 +12,8 @@ define( [
     var Card = Backbone.Model.extend( {
 
         defaults : {
-            radius : 10
+            radius : 10,
+            padding: 50,
         }
 
     } );
@@ -21,14 +22,20 @@ define( [
 
         initialize : function ( ) {
             this.model.on( 'change:radius', this.onRadiusChange, this );
+            this.model.on( 'change:padding', this.onPaddingChange, this );
         },
 
         render : function ( ) {
             this.onRadiusChange( );
+            this.onPaddingChange( );
         },
 
         onRadiusChange : function ( ) {
             this.$el.css( 'border-radius', this.model.get( 'radius' ) );
+        onPaddingChange : function ( ) {
+            this.$el.css( 'padding', this.model.get( 'padding' ) );
+        },
+
         }
 
     } );
@@ -49,6 +56,11 @@ define( [
     appearance.createWidget( 'Border radius', 'NumberedSlider', {
         model : card,
         name  : 'radius'
+    } );
+
+    appearance.createWidget( 'Paddings', 'NumberedSlider', {
+        model : card,
+        name  : 'padding'
     } );
 
 } );

--- a/sources/app.js
+++ b/sources/app.js
@@ -32,10 +32,10 @@ define( [
 
         onRadiusChange : function ( ) {
             this.$el.css( 'border-radius', this.model.get( 'radius' ) );
-        onPaddingChange : function ( ) {
-            this.$el.css( 'padding', this.model.get( 'padding' ) );
         },
 
+        onPaddingChange : function ( ) {
+            this.$el.css( 'padding', this.model.get( 'padding' ) );
         }
 
     } );

--- a/sources/app.js
+++ b/sources/app.js
@@ -32,20 +32,22 @@ define( [
     var View = Backbone.View.extend( {
 
         initialize : function ( ) {
-            this.model.on( 'change:radius',     this.bindPropertyChange( 'radius', 'border-radius' ), this );
-            this.model.on( 'change:padding',    this.bindPropertyChange( 'padding', 'padding' ), this );
-            this.model.on( 'change:background', this.bindPropertyChange( 'background', 'background-color' ), this );
-            this.model.on( 'change:title',      this.bindRichTextChange( 'title', '.name' ), this );
-            this.model.on( 'change:subtitle',   this.bindRichTextChange( 'subtitle', '.job' ), this );
-            this.model.on( 'all',               this.debugChange, this );
+            this.handlers = [ ];
+
+            this.addHandler( 'change:radius',     this.bindPropertyChange( 'radius', 'border-radius' ) );
+            this.addHandler( 'change:padding',    this.bindPropertyChange( 'padding', 'padding' ) );
+            this.addHandler( 'change:background', this.bindPropertyChange( 'background', 'background-color' ) );
+            this.addHandler( 'change:title',      this.bindRichTextChange( 'title', '.name' ) );
+            this.addHandler( 'change:subtitle',   this.bindRichTextChange( 'subtitle', '.job' ) );
         },
 
         render : function ( ) {
-            this.bindPropertyChange( 'radius', 'border-radius' )();
-            this.bindPropertyChange( 'padding', 'padding' )();
-            this.bindPropertyChange( 'background', 'background-color' )();
-            this.bindRichTextChange( 'title', '.name' )();
-            this.bindRichTextChange( 'subtitle', '.job' )();
+            this.handlers.forEach( handler => handler.call( this ) );
+        },
+
+        addHandler: function ( event, handler ) {
+            this.model.on( event, handler, this );
+            this.handlers.push( handler );
         },
 
         bindPropertyChange : function ( key, property ) {

--- a/sources/app.js
+++ b/sources/app.js
@@ -14,6 +14,16 @@ define( [
         defaults : {
             radius : 10,
             padding: 50,
+            title: {
+                text: 'Name',
+                size: 30,
+                color: '#ffffff'
+            },
+            subtitle: {
+                text: 'Job',
+                size: 20,
+                color: '#bbbbbb'
+            }
         }
 
     } );
@@ -23,11 +33,27 @@ define( [
         initialize : function ( ) {
             this.model.on( 'change:radius', this.onRadiusChange, this );
             this.model.on( 'change:padding', this.onPaddingChange, this );
+            this.model.on( 'change:title', this.bindRichTextChange( '.name', 'title' ), this );
+            this.model.on( 'change:subtitle', this.bindRichTextChange( '.job', 'subtitle' ), this );
+            this.model.on( 'all', this.debugChange, this );
         },
 
         render : function ( ) {
             this.onRadiusChange( );
             this.onPaddingChange( );
+            this.bindRichTextChange( '.name', 'title' )();
+            this.bindRichTextChange( '.job', 'subtitle' )();
+        },
+
+        bindRichTextChange: function ( selector, key ) {
+            var $richText = this.$el.find( selector );
+
+            return function ( ) {
+                var datas = this.model.get( key );
+                $richText.text( datas.text );
+                $richText.css( 'font-size', datas.size );
+                $richText.css( 'color', datas.color );
+            }.bind( this );
         },
 
         onRadiusChange : function ( ) {
@@ -61,6 +87,22 @@ define( [
     appearance.createWidget( 'Paddings', 'NumberedSlider', {
         model : card,
         name  : 'padding'
+    } );
+
+    appearance.createWidget( 'Title', 'RichText', {
+        model : card,
+        name  : 'title',
+        colorOptions : {
+            format: 'hex'
+        },
+    } );
+
+    appearance.createWidget( 'Subtitle', 'RichText', {
+        model : card,
+        name  : 'subtitle',
+        colorOptions : {
+            format: 'hex'
+        },
     } );
 
 } );

--- a/sources/utils/DeepObject.js
+++ b/sources/utils/DeepObject.js
@@ -1,0 +1,52 @@
+define({
+
+    /**
+     * Return a Boolean indicating if the sequence of `keys` exists in the object `obj` and its sub-objects.
+     */
+
+    has: function ( obj, keys ) {
+
+        if ( keys.length === 1 )
+            return (typeof obj[ keys[0] ] != 'undefined');
+        else if ( keys.length > 1 && typeof obj[ keys[0] ] != 'undefined' )
+            return this.has( obj[ keys[0] ], keys.slice(1) );
+        else
+            return false;
+
+    },
+
+    /**
+     * Return the value in the object `obj` and its sub-objects at the corresponding sequence of `keys`.
+     */
+
+    get: function ( obj, keys ) {
+
+        if (keys.length === 1)
+            return obj[ keys[0] ];
+        else
+            return this.get(obj[ keys[0] ], keys.slice(1));
+
+    },
+
+    /**
+     * Set `value` in the object `obj` and its sub-objects at the corresponding to a sequence of `keys`.
+     * If an object does not exists, it is created. Always return the updated object.
+     */
+
+    set: function ( obj, keys, value ) {
+
+        var key = keys[0];
+
+        if (typeof obj !== 'object')
+            obj = { };
+
+        if (keys.length === 0)
+            return value;
+        else
+            obj[key] = this.set( obj[key], keys.slice(1), value );
+
+        return obj;
+
+    }
+
+});

--- a/sources/vendors/editor.css
+++ b/sources/vendors/editor.css
@@ -4109,7 +4109,8 @@ textarea.form-input, textarea.form-listbox, textarea.form-prefixed-input {
   /* The +1 is because we have a right border */
   width: 291px;
   height: 100%;
-  padding-top: 55px; }
+  padding-top: 55px;
+  overflow: auto; }
 
 /* line 25, ../../../static/sass/editor/_layout.scss */
 .editor-view {


### PR DESCRIPTION
### 🚀  Add features for Card:
- Padding (Slider widget).
- Background color (Color widget).
- Title, Subtitle (RichText widget, see below).

### 🚀  Add widgets:
- Text: Simple `input[type=text]` widget.
- RichText: combination of `Text`, `Number` and `Color` widget to set the text, size and color of a rich text. Values are stored in the given model in the `.text`, `.size` and `.color` fields.

---

### ⚙️  Required changes:

- #### `Utils/DeepObjects`
  Add methods:
  - `DeepObject.has`: Return a Boolean indicating if the sequence of `keys` exists in the object `obj` and its sub-objects.
  - `DeepObject.get`: Return the value in the object `obj` and its sub-objects at the corresponding sequence of `keys`.
  - `DeepObject.set`: Set `value` in the object `obj` and its sub-objects at the corresponding to a sequence of `keys`. If an object does not exists, it is created. Always return the updated object.

- #### `Editor/Widget`: add support for sub-fields
  Add support for setting, getting and watching changes of deep objects in models.

  For example, `foo.bar.baz` can be set, retrieved and its changes are detected. Its value is stored in `foo.bar` in `foo` in the model. Specific events are triggered on change: `change:foo.bar.baz`, `change:foo.bar`, `change:foo` and `change`.

- #### `Editor/ColorWidget`: add support for multiple color formats
  Add methods:
  - `ColorWidget.rgbToHex`: convert a color from RGB to HEX
  - `ColorWidget.hexToRgb`: convert a color from HEX to RGB
  - `ColorWidget.convertColor`: convert a color from and to the requested colors. `this.options.format` is used as defaults.

  Add options:
  - `format`: format of the color set in the given model. Can be 'rgb' or 'hex'.

- #### Other various private changes:
  - `Editor/defaultWidgets`: Split argument list into several lines.
  - `Editor/Widget`: Fix ignored `which` by `defaultAction`.
  - `Editor/ColorWidget`: Fix colorPicker color not set on load.

---

### 📝  To Do:
- #### Improve the RichText widget design:
  - Text: Add a design on input.
  - Size: Use a select instead of a text input.
  - Color: Move it to a dropdown.

- #### Add Card features:
  - Border (Size, Color, Type).
  - Background Image.

- #### Add visual edition of Elements (Title, Subtitle):
  - Create/Delete an Element.
  - Select an Element to edit its properties.